### PR TITLE
ai-generated: fix jwt to jwtOptions for Feathers v5

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
       "usernameField": "email",
       "passwordField": "password"
     },
-    "jwt": {
+    "jwtOptions": {
       "header": {
         "type": "aceess"
       },


### PR DESCRIPTION
Change 'jwt' to 'jwtOptions' in config/default.json for Feathers v5 compatibility