### PR TITLE
ai-generated: remove expressOauth for Feathers v5

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -15,7 +15,7 @@
       "usernameField": "email",
       "passwordField": "password"
     },
-    "jwt": {
+    "jwtOptions": {
       "header": {
         "type": "aceess"
       },

--- a/src/authentication.js
+++ b/src/authentication.js
@@ -1,6 +1,5 @@
 const { AuthenticationService, JWTStrategy } = require('@feathersjs/authentication')
 const { LocalStrategy } = require('@feathersjs/authentication-local')
-const { expressOauth } = require('@feathersjs/authentication-oauth')
 
 module.exports = app => {
   const authentication = new AuthenticationService(app)
@@ -9,5 +8,4 @@ module.exports = app => {
   authentication.register('local', new LocalStrategy())
 
   app.use('/authentication', authentication)
-  app.configure(expressOauth())
 }


### PR DESCRIPTION
Remove expressOauth import and configure call since it is not available in Feathers v5 authentication-oauth package