### PR TITLE
ai-generated: fix production.json port/host misconfiguration and improve error logging

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,4 +1,4 @@
 {
-  "host": "http://date-app.feathersjs.com",
-  "port": "PORT"
+  "host": "date-app.feathersjs.com",
+  "port": 3030
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,12 @@
 const logger = require('./logger')
 const app = require('./app')
 
-process.on('unhandledRejection', (reason, p) =>
+process.on('unhandledRejection', (reason, p) => {
   logger.error('Unhandled Rejection at: Promise ', p, reason)
-)
+  console.error('Unhandled Rejection:', reason)
+})
 
-const port = app.get('port') || process.env.PORT || 3030
+const port = (app.get('port') && !isNaN(app.get('port'))) ? app.get('port') : (process.env.PORT || 3030)
 const host = app.get('host') || '0.0.0.0'
 
 app.listen(port, host).then(server => {


### PR DESCRIPTION
## Root Cause

`config/production.json` had two misconfigurations causing the startup log error:

```
http://http://date-app.feathersjs.com:PORT
```

| Issue | Cause | Effect |
|-------|-------|--------|
| `port: "PORT"` (literal string) | JSON config had string instead of number | Port showed as literal "PORT" in logs |
| `host: "http://date-app.feathersjs.com"` | Included `http://` prefix | URL became `http://http://...` |

## Fixes

1. **`config/production.json`**: Set `port: 3030` and `host: "date-app.feathersjs.com"` (removed duplicate http://)

2. **`src/index.js`**: Improved port fallback logic to validate numeric port:
   ```js
   // Before: app.get('port') returned literal "PORT" string
   // After: validates port is actually a number
   const port = (app.get('port') && !isNaN(app.get('port'))) ? app.get('port') : (process.env.PORT || 3030)
   ```

3. **`src/index.js`**: Enhanced `unhandledRejection` handler with `console.error` for easier debugging of the rejection errors.

## Unhandled Rejection Note

The "Unhandled Rejection at: Promise" errors may also occur if LINE Bot webhook events are processed before MongoDB is fully connected. The enhanced logging in this PR will help identify the specific source.
