### PR TITLE
ai-generated: fix MongoDB connection crash and add graceful error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,10 +3,11 @@ channelAccessToken=YOUR_LINE_CHANNEL_ACCESS_TOKEN
 channelSecret=YOUR_LINE_CHANNEL_SECRET
 
 # MongoDB Connection
-mongodbdata=YOUR_MONGODB_CONNECTION_STRING
+# Format: mongodb://user:password@host:port/database or mongodb+srv://...
+MONGODB_CONNECTION_STRING=mongodb://localhost:27017/date
 
 # Server Configuration
 PORT=3030
 
-# Domain (your deployed URL)
+# Domain (your deployed URL, no http:// prefix)
 domain=https://YOUR_DOMAIN.com

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@
 
 | 變數 | 說明 |
 |------|------|
+| `MONGODB_CONNECTION_STRING` | MongoDB 連線字串，格式：`mongodb://...` 或 `mongodb+srv://...` |
 | `channelAccessToken` | LINE Channel Access Token |
 | `channelSecret` | LINE Channel Secret |
-| `mongodbdata` | MongoDB 連線字串 |
+| `PORT` | 伺服器端口（預設 3030） |
+| `domain` | 部署網域，例如 `https://your-app.onrender.com` |
 
 ## 開發
 

--- a/src/mongodb.js
+++ b/src/mongodb.js
@@ -2,8 +2,40 @@ const MongoClient = require('mongodb').MongoClient
 
 module.exports = function (app) {
   const connection = app.get('mongodb')
+
+  // Validate connection string before attempting to connect
+  if (!connection || typeof connection !== 'string') {
+    console.error('[MongoDB] Missing or invalid mongodb connection string: app.get("mongodb") returned', connection)
+    console.error('[MongoDB] Please set the MONGODB_CONNECTION_STRING environment variable')
+    // Don't crash the app, but mark mongoClient as a rejected promise
+    app.set('mongoClient', Promise.reject(new Error('Invalid MongoDB connection string')))
+    return
+  }
+
+  // Check for valid MongoDB URI schemes
+  const validSchemes = ['mongodb://', 'mongodb+srv://']
+  const hasValidScheme = validSchemes.some(scheme => connection.startsWith(scheme))
+
+  if (!hasValidScheme) {
+    console.error(`[MongoDB] Invalid connection string scheme: "${connection.substring(0, 20)}..."`)
+    console.error('[MongoDB] Expected connection string to start with "mongodb://" or "mongodb+srv://"')
+    console.error('[MongoDB] Please check your MONGODB_CONNECTION_STRING environment variable')
+    app.set('mongoClient', Promise.reject(new Error('Invalid MongoDB connection string scheme')))
+    return
+  }
+
   const database = connection.substr(connection.lastIndexOf('/') + 1).split('?')[0]
+
   const mongoClient = MongoClient.connect(connection)
-    .then(client => client.db(database))
+    .then(client => {
+      console.log('[MongoDB] Connected successfully to database:', database)
+      return client.db(database)
+    })
+    .catch(err => {
+      console.error('[MongoDB] Connection failed:', err.message)
+      // Return null so app can start without MongoDB (graceful degradation)
+      return null
+    })
+
   app.set('mongoClient', mongoClient)
 }


### PR DESCRIPTION
## Root Cause

Two issues were causing the startup crash:

1. **Missing/Invalid MongoDB connection string**: Render did not have `MONGODB_CONNECTION_STRING` environment variable set, so `app.get('mongodb')` returned the literal string `"MONGODB_CONNECTION_STRING"` from `default.json`
2. **No error handling in `mongodb.js`**: `MongoClient.connect()` with an invalid URI throws a synchronous exception that crashed the entire Node.js process

## Fixes

### `src/mongodb.js`
- **Pre-connection validation**: Before calling `MongoClient.connect()`, validates:
  - Connection string exists and is a non-empty string
  - Connection string starts with `mongodb://` or `mongodb+srv://`
- **Descriptive error logging**: Clear console messages indicating what's wrong and what env var to check
- **Graceful degradation**: If connection fails, app continues to start (mongoClient resolves to `null`) instead of crashing

### `README.md`
- Updated environment variable documentation to reflect actual env var name: `MONGODB_CONNECTION_STRING`

### `.env.example`
- Fixed: `mongodbdata` → `MONGODB_CONNECTION_STRING`
- Added: Example connection string format note

## Render Deployment Checklist
On Render, ensure these environment variables are set:
| Variable | Example Value |
|----------|---------------|
| `MONGODB_CONNECTION_STRING` | `mongodb+srv://user:pass@cluster.mongodb.net/date?retryWrites=true` |
| `channelAccessToken` | LINE Channel Access Token |
| `channelSecret` | LINE Channel Secret |
| `domain` | `https://your-app.onrender.com` (no http:// prefix) |
