### PR TITLE
ai-generated: add null checks for mongoClient in all service classes

### DIFF
--- a/src/services/menus/menus.class.js
+++ b/src/services/menus/menus.class.js
@@ -5,6 +5,10 @@ exports.Menus = class Menus extends Service {
     super(options)
 
     app.get('mongoClient').then(db => {
+      if (db == null) {
+        console.warn('[Menus] MongoDB not connected, service unavailable')
+        return
+      }
       this.Model = db.collection('menus')
     })
   }

--- a/src/services/orders/orders.class.js
+++ b/src/services/orders/orders.class.js
@@ -5,6 +5,10 @@ exports.Orders = class Orders extends Service {
     super(options)
 
     app.get('mongoClient').then(db => {
+      if (db == null) {
+        console.warn('[Orders] MongoDB not connected, service unavailable')
+        return
+      }
       this.Model = db.collection('orders')
     })
   }

--- a/src/services/uploads/uploads.class.js
+++ b/src/services/uploads/uploads.class.js
@@ -4,6 +4,10 @@ exports.Uploads = class Uploads extends Service {
   constructor (options, app) {
     super(options)
     app.get('mongoClient').then(db => {
+      if (db == null) {
+        console.warn('[Uploads] MongoDB not connected, service unavailable')
+        return
+      }
       this.Model = db.collection('uploads')
     })
   }

--- a/src/services/user/user.class.js
+++ b/src/services/user/user.class.js
@@ -5,6 +5,10 @@ exports.User = class User extends Service {
     super(options)
 
     app.get('mongoClient').then(db => {
+      if (db == null) {
+        console.warn('[User] MongoDB not connected, service unavailable')
+        return
+      }
       this.Model = db.collection('user')
     })
   }


### PR DESCRIPTION
## Problem

When MongoDB connection fails (null), all 4 service classes crashed with:

```
TypeError: Cannot read properties of null (reading 'collection')
```

This happened because `mongoClient` was `null` but service classes tried to call `.collection()` on it.

## Fix

Added null check in all 4 service classes:

```js
app.get('mongoClient').then(db => {
  if (db == null) {
    console.warn('[Service] MongoDB not connected, service unavailable')
    return
  }
  this.Model = db.collection('...')
})
```

## Services Fixed
- `src/services/user/user.class.js`
- `src/services/orders/orders.class.js`
- `src/services/uploads/uploads.class.js`
- `src/services/menus/menus.class.js`

## ⚠️ Still Need to Fix on Render

The root cause is still that `MONGODB_CONNECTION_STRING` env var on Render is set to the literal string `"MONGODB_CONNECTION_STRING"` instead of the actual MongoDB URI.

On Render dashboard, please set:
- **Key**: `MONGODB_CONNECTION_STRING`
- **Value**: `mongodb+srv://chrislin0621:你的密碼@cluster.mongodb.net/date` (the full Atlas connection string)
