### PR TITLE
ai-generated: fix production host binding from invalid hostname to 0.0.0.0

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -1,4 +1,4 @@
 {
-  "host": "date-app.feathersjs.com",
+  "host": "0.0.0.0",
   "port": 3030
 }


### PR DESCRIPTION
## Problem had  which is an invalid hostname, causing:## Fix- Changed  in  from  to -  binds to all network interfaces, allowing the server to accept connections properly on Render## Render Environment Variables ChecklistEnsure these are set on Render:| Variable | Example Value | Notes ||----------|---------------|-------||  |  | Full Atlas URI ||  |  | No http:// prefix, used for LINE Bot callbacks ||  |  | LINE Channel Access Token ||  |  | LINE Channel Secret |