### PR TITLE
ai-generated: fix port priority to honor PORT env var from Render

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ process.on('unhandledRejection', (reason, p) => {
   console.error('Unhandled Rejection:', reason)
 })
 
-const port = (app.get('port') && !isNaN(app.get('port'))) ? app.get('port') : (process.env.PORT || 3030)
+const port = process.env.PORT || app.get('port') || 3030
 const host = app.get('host') || '0.0.0.0'
 
 app.listen(port, host).then(server => {


### PR DESCRIPTION
## Fix

Render sets `PORT=3000` but the app was ignoring it and using hardcoded `3030` from config.

Changed port priority:
```js
// Before: app.get('port') took precedence
// After: process.env.PORT takes priority for Render compatibility
const port = process.env.PORT || app.get('port') || 3030
```

## ⚠️ Still Need to Fix on Render

The MongoDB error persists:
```
[MongoDB] Invalid connection string scheme: "MONGODB_CONNECTION_S..."
```

This means `MONGODB_CONNECTION_STRING` env var on Render is still set to the literal string `"MONGODB_CONNECTION_STRING"`, not the actual MongoDB URI.

**Please go to Render Dashboard → Environment → and set:**
| Key | Value |
|-----|-------|
| `MONGODB_CONNECTION_STRING` | `mongodb+srv://chrislin0621:你的密碼@cluster.mongodb.net/date` |
