### PR TITLE
ai-generated: revert mongodb env var to original mongodbdata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ channelSecret=YOUR_LINE_CHANNEL_SECRET
 
 # MongoDB Connection
 # Format: mongodb://user:password@host:port/database or mongodb+srv://...
-MONGODB_CONNECTION_STRING=mongodb://localhost:27017/date
+mongodbdata=mongodb://localhost:27017/date
 
 # Server Configuration
 PORT=3030

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 | 變數 | 說明 |
 |------|------|
-| `MONGODB_CONNECTION_STRING` | MongoDB 連線字串，格式：`mongodb://...` 或 `mongodb+srv://...` |
+| `mongodbdata` | MongoDB 連線字串，格式：`mongodb://...` 或 `mongodb+srv://...` |
 | `channelAccessToken` | LINE Channel Access Token |
 | `channelSecret` | LINE Channel Secret |
 | `PORT` | 伺服器端口（預設 3030） |

--- a/config/default.json
+++ b/config/default.json
@@ -27,7 +27,7 @@
       }
     }
   },
-  "mongodb": "MONGODB_CONNECTION_STRING",
+  "mongodb": "mongodbdata",
   "domain": "https://YOUR_DOMAIN.com",
   "uploadPath": "/builduploads/",
   "uploadShowPath": "/uploads/"


### PR DESCRIPTION
## Change

Reverted MongoDB env var name back to original `mongodbdata` (instead of `MONGODB_CONNECTION_STRING`).

Since Render already has `mongodbdata` set as the env var name, this avoids needing to change Render settings.

## Files Changed
- `config/default.json`: `MONGODB_CONNECTION_STRING` -> `mongodbdata`
- `README.md`: updated env var documentation
- `.env.example`: updated example

## No Render Changes Needed
After merging this PR, the existing `mongodbdata` env var on Render will work as-is.
