### PR TITLE
ai-generated: fix mongodb config to read from mongodbdata env var

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -27,7 +27,7 @@
       }
     }
   },
-  "mongodb": "mongodbdata",
+  "mongodb": "${mongodbdata}",
   "domain": "https://YOUR_DOMAIN.com",
   "uploadPath": "/builduploads/",
   "uploadShowPath": "/uploads/"


### PR DESCRIPTION
## ProblemFeathers was looking for `MONGODB` or `APP_MONGODB` env vars, but Render has `mongodbdata` as the env var name.## FixChanged `config/default.json` from:to:Now Feathers will directly read the `mongodbdata` environment variable (which is already set correctly in Render).