### PR TITLE
ai-generated: read mongodbdata directly from process.env

### DIFF
--- a/src/mongodb.js
+++ b/src/mongodb.js
@@ -1,18 +1,12 @@
 const MongoClient = require('mongodb').MongoClient
 
 module.exports = function (app) {
-  let connection
-  try {
-    connection = app.get('mongodb')
-  } catch (err) {
-    console.error('[MongoDB] Failed to get mongodb config:', err.message)
-    app.set('mongoClient', Promise.resolve(null))
-    return
-  }
+  // Read connection string from mongodbdata env var directly (Feathers config substitution may not work for this key)
+  const connection = process.env.mongodbdata || app.get('mongodb')
 
   // Validate connection string before attempting to connect
   if (!connection || typeof connection !== 'string') {
-    console.error('[MongoDB] Missing or invalid mongodb connection string: app.get("mongodb") returned', connection)
+    console.error('[MongoDB] Missing or invalid mongodb connection string. Checked process.env.mongodbdata and app.get("mongodb"):', connection)
     console.error('[MongoDB] Please set the mongodbdata environment variable')
     app.set('mongoClient', Promise.resolve(null))
     return


### PR DESCRIPTION
## Problem

`config/default.json` has `"mongodb": "${mongodbdata}"` expecting Feathers to substitute the env var, but the substitution wasn't working. As a result, `app.get('mongodb')` returned the literal string `"mongodbdata"`.

## Fix

Modified `src/mongodb.js` to read directly from `process.env.mongodbdata` first:

```js
const connection = process.env.mongodbdata || app.get('mongodb')
```

This bypasses the Feathers config substitution and ensures the `mongodbdata` env var (which you already have set correctly in Render) is actually used.

## Why This Works
- `process.env.mongodbdata` → reads the Render env var directly (which you set to the real Atlas URI)
- `app.get('mongodb')` → fallback to config value
