### PR TITLE
ai-generated: fix static file path resolution in production

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -41,7 +41,7 @@ app.get('/err/noAuth', (req, res) => { // 沒有權限之跳轉頁面
 })
 
 // app.use('/', express.static(app.get('public')));
-app.use('/', express.static(app.get('public')))
+app.use('/', express.static(path.join(__dirname, '..', 'public', 'build')))
 
 app.get('/seller', (req, res) => { // 導到/ezcon
   res.sendFile(path.join(app.get('public'), '/index.html'))


### PR DESCRIPTION
## Problem uses  relative to Render's working directory, which may not be the project root, causing 404 errors.## FixChanged static file serving to use an explicit absolute path:This ensures the path is always resolved relative to  location, regardless of where Node.js is started from.