### PR TITLE
fix: correct uploads path and ObjectId driver casing

### DIFF
--- a/src/services/uploads/uploads.hooks.js
+++ b/src/services/uploads/uploads.hooks.js
@@ -1,7 +1,7 @@
 const fs = require('fs')// --For 刪除檔案
 const { promisify } = require('util')// --For 刪除檔案
 const unlinkAsync = promisify(fs.unlink)// --For 刪除檔案
-const { ObjectID } = require('mongodb')
+const { ObjectId } = require('mongodb')
 
 // uploads Removed => 本機(單一)檔案移除
 const removeDirFile = async (context) => {
@@ -26,7 +26,7 @@ const removeOtherTodayMenu = async (context) => { // 移除 其他有該key的 u
       {
         $unset: { isMenu: '' }// 刪除'user'相關驗證data
       },
-      { query: { _id: { $ne: new ObjectID(result._id) } } }
+      { query: { _id: { $ne: new ObjectId(result._id) } } }
     )
     return context
   } catch (error) {

--- a/src/services/uploads/uploads.service.js
+++ b/src/services/uploads/uploads.service.js
@@ -2,10 +2,10 @@ const express = require('@feathersjs/express')
 const { Uploads } = require('./uploads.class')
 const hooks = require('./uploads.hooks')
 const multer = require('multer')// 多檔案上傳
-const { ObjectID } = require('mongodb')
+const { ObjectId } = require('mongodb')
 const fs = require('fs')// --For 刪除檔案
 
-const BaseUploadsRoute = 'public/build/uploads/'// 上傳檔案放置路徑
+const BaseUploadsRoute = 'public/uploads/'// 上傳檔案放置路徑
 
 const AllowsType = ['userPerson']
 const AllowTypeWithService = ['menus']
@@ -99,11 +99,11 @@ const handlePatchService = (app, sName, body, users, uid) => { // 更新service 
       // const Res = await app.service('vote').create(body,{ user:users });
 
       if (Object.keys(body).length === 0) { // body為空
-        const Res = await app.service(sName).find({ query: { _id: new ObjectID(uid) } })
+        const Res = await app.service(sName).find({ query: { _id: new ObjectId(uid) } })
         if (Res.total > 0) resolve(Res.data[0]._id)
         else { return reject(new Error('找不到該id資料')) }
       } else { // 更新body不為空時
-        const Res = await app.service(sName).patch(new ObjectID(uid), body)
+        const Res = await app.service(sName).patch(new ObjectId(uid), body)
         resolve(Res._id)
       }
     } catch (error) {


### PR DESCRIPTION
## Fixes\n\n### uploads path\n- Changed from `public/build/uploads/` to `public/uploads/`\n\n### ObjectId casing  \n- Newer mongodb driver uses `ObjectId` (lowercase d), not `ObjectID`\n- Fixed in uploads.service.js and uploads.hooks.js\n\n⚠️ **Human review required**