### PR TITLE
fix: read domain directly from process.env

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
     }
   },
   "mongodb": "mongodbdata",
-  "domain": "https://YOUR_DOMAIN.com",
+  "domain": "http://localhost:3030",
   "uploadPath": "/builduploads/",
   "uploadShowPath": "/uploads/"
 }

--- a/src/middleware/routes/line.js
+++ b/src/middleware/routes/line.js
@@ -77,7 +77,7 @@ function createAccountById (app, uid) {
         name: trueName.displayName ? trueName.displayName : uid,
         img: trueName.pictureUrl ? trueName.pictureUrl : ''
       })
-      let doMain = app.get('domain')
+      let doMain = process.env.domain || app.get('domain')
       const btEd = btoa(`a=${uid}&d=${randomPSD}`)
       doMain = doMain + '?e=' + btEd
       return resolve(doMain)


### PR DESCRIPTION
## ProblemSame issue as mongodbdata - Feathers config convention expects APP_DOMAIN env var, but Render sets `domain`.## Fixline.js now reads directly: `process.env.domain || app.get('domain')`