### PR TITLE
fix: use ${domain} in config to read domain env var directly

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -28,7 +28,7 @@
     }
   },
   "mongodb": "mongodbdata",
-  "domain": "http://localhost:3030",
+  "domain": "${domain}",
   "uploadPath": "/builduploads/",
   "uploadShowPath": "/uploads/"
 }


### PR DESCRIPTION
Changed domain config from localhost fallback to ${domain} so Feathers reads from Render's domain environment variable.